### PR TITLE
feat: Add XML source/sink with optional XSD schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently, the following options for sources and sinks are available:
 * [Parquet](#parquet) (`parquet://`)
 * [Delta](#delta) (`delta://`)
 * [Excel](#excel) (`xlsx://`)
+* [XML](#xml) (`xml://`)
 * [Hive](#hive) (`hive://`)
 * [Kafka](#kafka) (`kafka://`)
 * [Solr](#solr) (`solr://`)
@@ -95,6 +96,30 @@ delta:///path/to/parquet/directory
 xlsx:///path/to/some.xlsl
 ```
 [Reads/writes given Excel file](excel/src/main/scala/dev/mauch/spark/dfio/ExcelFileDataFrameSource.scala).
+
+### XML
+```
+xml:///path/to/data.xml?rowTag=book
+```
+[Reads/writes XML files](xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala) via
+[spark-xml](https://github.com/databricks/spark-xml).
+
+**Reading**: `rowTag` selects the element that becomes one row (default `ROW`). Any other query
+parameter is passed straight through as a spark-xml read option (e.g. `mode`, `charset`,
+`attributePrefix`).
+
+An XSD can be supplied to define the schema and validate the input:
+```
+xml:///path/to/data.xml?rowTag=book&xsd=/path/to/schema.xsd
+```
+When `xsd` is given, the read schema is derived from the XSD (typed columns instead of spark-xml's
+inference) and every row is validated against it. Combine with `mode=DROPMALFORMED` to drop rows
+that fail validation, or the default `mode=PERMISSIVE` to route them to the corrupt-record column.
+The XSD's root element must describe a single row (i.e. the `rowTag` element).
+
+**Writing**: rows are written as `<ROWS><ROW>…</ROW></ROWS>`. Note that spark-xml (0.18.0) does not
+apply write options, so `rowTag`/`rootTag` cannot currently customize the written element names.
+The `xsd` parameter applies to reading only.
 
 ### Hive
 ```

--- a/build.mill
+++ b/build.mill
@@ -121,6 +121,12 @@ trait ExcelModule extends DfioModule {
 }
 object excel extends Cross[ExcelModule](crossMatrix)
 
+trait XmlModule extends DfioModule {
+  def moduleDeps = Seq(core())
+  def ivyDeps = Agg(ivy"com.databricks::spark-xml:0.18.0")
+}
+object xml extends Cross[XmlModule](crossMatrix)
+
 trait KafkaModule extends DfioModule with ConfluentRepo {
   def moduleDeps = Seq(core(), serde())
   def ivyDeps = Agg(ivy"org.apache.spark::spark-sql-kafka-0-10:$sparkVersion")
@@ -173,7 +179,7 @@ trait EtlModule extends DfioModule with HwcModule with ConfluentRepo with BuildI
   def resources = super.resources() ++ Seq(PathRef(millSourcePath / os.up / "README.md"))
 
   object test extends SbtTests with TestModule.ZioTest {
-    def moduleDeps = super.moduleDeps ++ etlModule.moduleDeps ++ Seq(kafka(), delta(), avro(), diff())
+    def moduleDeps = super.moduleDeps ++ etlModule.moduleDeps ++ Seq(kafka(), delta(), avro(), diff(), xml())
     def ivyDeps = Agg(
       ivy"dev.zio::zio-test:2.1.24",
       ivy"dev.zio::zio-test-sbt:2.1.24",

--- a/etl/src/test/scala/dev/mauch/spark/dfio/ETLTest.scala
+++ b/etl/src/test/scala/dev/mauch/spark/dfio/ETLTest.scala
@@ -164,8 +164,8 @@ object ETLTest extends ZIOSpecDefault {
           .attempt {
             val schema = org.apache.spark.sql.Encoders.product[Employee].schema
             val schemaURL = java.net.URLEncoder.encode(schema.json, "UTF-8")
-            val bossRelationsSchema = org.apache.spark.sql.Encoders[BossRelation].schema
-            val $bossRelationsSchemaURL = java.net.URLEncoder.encode(bossRelationsSchema.json, "UTF-8")
+            val bossRelationsSchema = org.apache.spark.sql.Encoders.product[BossRelation].schema
+            val bossRelationsSchemaURL = java.net.URLEncoder.encode(bossRelationsSchema.json, "UTF-8")
             val args = s"""
             --master local[*]
             --source employees+kafka-stream://${bootstrapServers.replaceFirst(

--- a/etl/src/test/scala/dev/mauch/spark/dfio/XmlEtlTest.scala
+++ b/etl/src/test/scala/dev/mauch/spark/dfio/XmlEtlTest.scala
@@ -1,0 +1,129 @@
+package dev.mauch.spark.dfio
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.LongType
+
+import java.nio.file.{Files, Path}
+
+object XmlEtlTest extends ZIOSpecDefault {
+  private val sparkLayer: ZLayer[Scope, Throwable, SparkSession] = ZLayer.scoped(ZIO.acquireRelease {
+    ZIO.attempt(SparkSession.builder().appName("XmlEtlTest").master("local[*]").getOrCreate())
+  }(spark => ZIO.succeed(spark.close())))
+
+  private val tempDirLayer: ZLayer[Scope, Throwable, Path] = ZLayer {
+    ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory("dataframe-io-xml-test")))(_ => ZIO.unit)
+  }
+
+  private def source(uri: String, spark: SparkSession): DataFrameSource with DataFrameSink =
+    new XmlUriParser().apply(new java.net.URI(uri))(spark)
+
+  def spec = suite("XML ETL Test")(
+    test("round-trips a DataFrame through XML preserving values") {
+      for {
+        spark <- ZIO.service[SparkSession]
+        dir <- ZIO.service[Path]
+        out = s"$dir/roundtrip"
+        result <- ZIO.attempt {
+          import spark.implicits._
+          val input = Seq((1L, "Alice"), (2L, "Bob"), (3L, "Charlie")).toDF("id", "name")
+          source(s"xml://$out", spark).write(input)
+          val readBack = source(s"xml://$out", spark).read()
+          readBack.orderBy("id").collect().map(r => (r.getAs[Long]("id"), r.getAs[String]("name"))).toSeq
+        }
+      } yield assert(result)(equalTo(Seq((1L, "Alice"), (2L, "Bob"), (3L, "Charlie"))))
+    },
+    test("reads externally-tagged XML by rowTag") {
+      for {
+        spark <- ZIO.service[SparkSession]
+        dir <- ZIO.service[Path]
+        xml = writeXml(
+          dir,
+          "books",
+          """<catalog>
+            |  <book><id>1</id><title>SICP</title></book>
+            |  <book><id>2</id><title>TAPL</title></book>
+            |</catalog>""".stripMargin
+        )
+        titles <- ZIO.attempt {
+          source(s"xml://$xml?rowTag=book", spark)
+            .read()
+            .orderBy("id")
+            .collect()
+            .map(_.getAs[String]("title"))
+            .toSeq
+        }
+      } yield assert(titles)(equalTo(Seq("SICP", "TAPL")))
+    },
+    test("derives a typed schema from an XSD") {
+      for {
+        spark <- ZIO.service[SparkSession]
+        dir <- ZIO.service[Path]
+        xsd = writeXsd(dir)
+        xml = writeXml(
+          dir,
+          "valid",
+          """<people>
+            |  <person><id>1</id><name>Alice</name><age>30</age></person>
+            |  <person><id>2</id><name>Bob</name><age>25</age></person>
+            |</people>""".stripMargin
+        )
+        schema <- ZIO.attempt(source(s"xml://$xml?rowTag=person&xsd=$xsd", spark).read().schema)
+      } yield assert(schema.map(_.name).toSet)(equalTo(Set("id", "name", "age"))) &&
+        assert(schema("id").dataType)(equalTo(LongType))
+    },
+    test("drops rows that fail XSD validation") {
+      for {
+        spark <- ZIO.service[SparkSession]
+        dir <- ZIO.service[Path]
+        xsd = writeXsd(dir)
+        // the second person is missing the required <name> element -> invalid against the XSD
+        xml = writeXml(
+          dir,
+          "invalid",
+          """<people>
+            |  <person><id>1</id><name>Alice</name><age>30</age></person>
+            |  <person><id>2</id><age>25</age></person>
+            |  <person><id>3</id><name>Charlie</name><age>35</age></person>
+            |</people>""".stripMargin
+        )
+        ids <- ZIO.attempt {
+          source(s"xml://$xml?rowTag=person&xsd=$xsd&mode=DROPMALFORMED", spark)
+            .read()
+            .collect()
+            .map(_.getAs[Long]("id"))
+            .toSeq
+            .sorted
+        }
+      } yield assert(ids)(equalTo(Seq(1L, 3L)))
+    }
+  ).provideSomeLayer[Scope with SparkSession](tempDirLayer)
+    .provideSomeLayerShared[Scope](sparkLayer) @@ TestAspect.sequential
+
+  private def writeXsd(dir: Path): String = {
+    val xsd =
+      """<?xml version="1.0" encoding="UTF-8"?>
+        |<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        |  <xs:element name="person">
+        |    <xs:complexType>
+        |      <xs:sequence>
+        |        <xs:element name="id" type="xs:long"/>
+        |        <xs:element name="name" type="xs:string"/>
+        |        <xs:element name="age" type="xs:int"/>
+        |      </xs:sequence>
+        |    </xs:complexType>
+        |  </xs:element>
+        |</xs:schema>""".stripMargin
+    val path = dir.resolve("person.xsd")
+    Files.write(path, xsd.getBytes("UTF-8"))
+    path.toString
+  }
+
+  private def writeXml(dir: Path, name: String, body: String): String = {
+    val path = dir.resolve(s"$name.xml")
+    Files.write(path, s"""<?xml version="1.0" encoding="UTF-8"?>\n$body""".getBytes("UTF-8"))
+    path.toString
+  }
+}

--- a/xml/src/main/resources/META-INF/services/dev.mauch.spark.dfio.DataFrameUriParser
+++ b/xml/src/main/resources/META-INF/services/dev.mauch.spark.dfio.DataFrameUriParser
@@ -1,0 +1,1 @@
+dev.mauch.spark.dfio.XmlUriParser

--- a/xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala
+++ b/xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala
@@ -1,0 +1,50 @@
+package dev.mauch.spark.dfio
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.types.{StructField, StructType}
+import com.databricks.spark.xml.util.XSDToSchema
+
+import java.nio.file.Paths
+
+import UriHelpers._
+
+case class XmlFileDataFrameSource(spark: SparkSession, path: String, options: Map[String, String] = Map.empty)
+    extends DataFrameSource
+    with DataFrameSink {
+
+  private val xsdPath: Option[String] = options.get("xsd")
+  // xsd drives per-row validation on read; every other query param passes straight to spark-xml
+  private val readOptions: Map[String, String] =
+    (options - "xsd") ++ xsdPath.map("rowValidationXSDPath" -> _)
+
+  override def read(): DataFrame = {
+    val reader = spark.read.format("xml").options(readOptions)
+    // xsd also supplies the schema, giving typed columns instead of inference
+    xsdPath.fold(reader)(p => reader.schema(rowSchemaFromXsd(p))).load(path)
+  }
+
+  // XSDToSchema returns the row element wrapped as a single struct field (e.g. the rowTag element);
+  // spark-xml expects the schema of one row's *contents*, so unwrap that single struct.
+  private def rowSchemaFromXsd(xsd: String): StructType =
+    XSDToSchema.read(Paths.get(xsd)) match {
+      case StructType(Array(StructField(_, inner: StructType, _, _))) => inner
+      case other => other
+    }
+
+  override def write(df: DataFrame): Boolean = {
+    // spark-xml validates against an XSD on read only, so drop the xsd option when writing
+    df.write
+      .mode(SaveMode.Overwrite)
+      .format("xml")
+      .options(options - "xsd")
+      .save(path)
+    true
+  }
+}
+
+class XmlUriParser extends DataFrameUriParser {
+  def schemes: Seq[String] = Seq("xml")
+  override def apply(uri: java.net.URI): SparkSession => DataFrameSource with DataFrameSink = { spark =>
+    XmlFileDataFrameSource(spark, uri.getPath, options = uri.queryParams)
+  }
+}


### PR DESCRIPTION
## What

Adds **XML** as a supported input/output format on the Scala/Spark side, with optional `.xsd` schema support — a new `xml` connector module mirroring the existing `excel`/`avro` connectors.

Usage:
```
xml:///path/to/data.xml?rowTag=book                    # read/write XML
xml:///path/to/data.xml?rowTag=book&xsd=/schema.xsd    # + XSD schema & row validation
```

## How

- **New `xml` module** (`build.mill`): depends on `com.databricks:spark-xml:0.18.0`, cross-built over the full Scala × Spark matrix like the other connectors. Registered via `ServiceLoader` (`META-INF/services/...DataFrameUriParser`) and added to the `etl` test classpath.
- **`XmlFileDataFrameSource`**: `xml://` source + sink. Reading honors `rowTag` and passes other query params straight through as spark-xml options. `?xsd=` derives a typed read schema from the XSD (unwrapping the row element's content, since `XSDToSchema` wraps it) **and** validates each row via `rowValidationXSDPath`; pair with `mode=DROPMALFORMED` to drop invalid rows.
- **Tests** (`XmlEtlTest`): round-trip, `rowTag` reads of externally-tagged XML, XSD-derived schema, and XSD validation dropping malformed rows. All 4 pass (Java 11 / Spark 3.5.8, matching CI's JDK).

## Notes / limitations

- **Write options are not applied by spark-xml.** Verified empirically (spark-xml 0.17.0 **and** 0.18.0, Spark 3.4.1 **and** 3.5.8, via `.option()`, `.options(Map)`, and the implicit `.xml()` writer) that spark-xml ignores all write options — `rowTag`, `rootTag`, `nullValue`, etc. A CSV control in the same run honored its options, so it's specific to spark-xml, not the environment. Consequently the sink always writes default `<ROWS>/<ROW>` element names. Round-trips work with the default tags. This is documented in the README. If customizable write tags are needed, we'd have to write XML via a custom serializer (out of scope here).
- **Drive-by fix**: `ETLTest.scala` had two pre-existing compile errors on `main` (`Encoders[BossRelation]` → `Encoders.product`, and a stray `$` in a `val` name) that prevented the `etl` test module from compiling at all. Fixed so the test module builds.

## Verification
```
./mill "xml[2.13.18,3.5.8].compile"          # + 2.12.21/3.2.4 corner cell
./mill __.reformat
JAVA_HOME=<jdk11> ./mill "etl[2.13.18,3.5.8].test.testOnly" dev.mauch.spark.dfio.XmlEtlTest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg352v7gbKxXNY8LhWGcXA
