### PR TITLE
feat: Add Spark 4.0 cross-target with native XML datasource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
+      # Spark 4.x requires Java 17+; Spark 3.x builds/tests on Java 11.
+      - name: Select JDK version
+        id: jdk
+        run: echo "version=${{ startsWith(matrix.spark, '4') && '17' || '11' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Download Java (temurin@${{ steps.jdk.outputs.version }})
+        id: download-java
         uses: typelevel/download-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: ${{ steps.jdk.outputs.version }}
 
-      - name: Setup Java (temurin@11)
+      - name: Setup Java (temurin@${{ steps.jdk.outputs.version }})
         uses: actions/setup-java@v5
         with:
           distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
+          java-version: ${{ steps.jdk.outputs.version }}
+          jdkFile: ${{ steps.download-java.outputs.jdkFile }}
 
       - name: Cache mill
         uses: actions/cache@v5

--- a/README.md
+++ b/README.md
@@ -99,27 +99,30 @@ xlsx:///path/to/some.xlsl
 
 ### XML
 ```
-xml:///path/to/data.xml?rowTag=book
+xml:///path/to/data.xml?rowTag=book&rootTag=catalog
 ```
-[Reads/writes XML files](xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala) via
-[spark-xml](https://github.com/databricks/spark-xml).
+[Reads/writes XML files](xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala). The
+underlying implementation depends on the Spark version: **Spark 4.0+** uses Spark's built-in XML
+datasource, **Spark 3.x** uses the [spark-xml](https://github.com/databricks/spark-xml) library.
+Both register under the `xml` short name, so the same URIs work on either.
 
-**Reading**: `rowTag` selects the element that becomes one row (default `ROW`). Any other query
-parameter is passed straight through as a spark-xml read option (e.g. `mode`, `charset`,
-`attributePrefix`).
+`rowTag` selects the element that becomes one row and `rootTag` the wrapping element written around
+them; both default to `ROW`/`ROWS`. Any other query parameter is passed straight through as an
+option (e.g. `mode`, `charset`, `attributePrefix`).
 
-An XSD can be supplied to define the schema and validate the input:
+An XSD can be supplied to define the read schema and validate the input:
 ```
 xml:///path/to/data.xml?rowTag=book&xsd=/path/to/schema.xsd
 ```
-When `xsd` is given, the read schema is derived from the XSD (typed columns instead of spark-xml's
-inference) and every row is validated against it. Combine with `mode=DROPMALFORMED` to drop rows
-that fail validation, or the default `mode=PERMISSIVE` to route them to the corrupt-record column.
-The XSD's root element must describe a single row (i.e. the `rowTag` element).
+When `xsd` is given, the read schema is derived from the XSD (typed columns instead of inference)
+and every row is validated against it. Combine with `mode=DROPMALFORMED` to drop rows that fail
+validation, or the default `mode=PERMISSIVE` to route them to the corrupt-record column. The XSD's
+root element must describe a single row (i.e. the `rowTag` element). The `xsd` parameter applies to
+reading only.
 
-**Writing**: rows are written as `<ROWS><ROW>…</ROW></ROWS>`. Note that spark-xml (0.18.0) does not
-apply write options, so `rowTag`/`rootTag` cannot currently customize the written element names.
-The `xsd` parameter applies to reading only.
+**Write note:** on **Spark 4.0+** `rowTag`/`rootTag` are honored when writing (the built-in
+datasource is a proper file format). On **Spark 3.x** the spark-xml library ignores write options, so
+the sink always emits the default `<ROWS>/<ROW>` element names regardless of `rowTag`/`rootTag`.
 
 ### Hive
 ```

--- a/build.mill
+++ b/build.mill
@@ -62,9 +62,12 @@ val spark32 = List("3.2.4")
 val spark33 = List("3.3.4")
 val spark34 = List("3.4.1", "3.4.4")
 val spark35 = List("3.5.8")
+val spark40 = List("4.0.0")
+// Spark 3.x supports Scala 2.12 and 2.13; Spark 4.x is Scala 2.13 only (and needs Java 17+).
 val sparkVersions = spark32 ++ spark33 ++ spark34 ++ spark35
+val sparkVersions213 = sparkVersions ++ spark40
 val crossMatrix212 = sparkVersions.map(spark => (scala212, spark))
-val crossMatrix213 = sparkVersions.filter(_ >= "3.2").map(spark => (scala213, spark))
+val crossMatrix213 = sparkVersions213.filter(_ >= "3.2").map(spark => (scala213, spark))
 val crossMatrix = crossMatrix212 ++ crossMatrix213
 
 object core extends Cross[DfioModule](crossMatrix)
@@ -99,6 +102,7 @@ trait DeltaModule extends DfioModule {
     case v if v.startsWith("3.2") => "2.0.0"
     case v if v.startsWith("3.3") => "2.3.0"
     case v if v.startsWith("3.4") => "2.4.0"
+    case v if v.startsWith("4.") => "4.0.0"
     case _ => "3.3.0"
   }
   val artifact = deltaVersion.split("\\.").head match {
@@ -117,13 +121,20 @@ object avro extends Cross[AvroModule](crossMatrix)
 
 trait ExcelModule extends DfioModule {
   def moduleDeps = Seq(core())
-  def ivyDeps = Agg(ivy"dev.mauch::spark-excel:${sparkVersion}_0.30.2")
+  val excelVersion = if (sparkMajor.toInt >= 4) s"${sparkVersion}_0.31.2" else s"${sparkVersion}_0.30.2"
+  def ivyDeps = Agg(ivy"dev.mauch::spark-excel:$excelVersion")
 }
 object excel extends Cross[ExcelModule](crossMatrix)
 
 trait XmlModule extends DfioModule {
   def moduleDeps = Seq(core())
-  def ivyDeps = Agg(ivy"com.databricks::spark-xml:0.18.0")
+  // Spark 4.0+ has a native XML datasource in spark-sql; older Spark needs the databricks spark-xml library.
+  val isNativeXml = sparkMajor.toInt >= 4
+  def ivyDeps = if (isNativeXml) Agg.empty[Dep] else Agg(ivy"com.databricks::spark-xml:0.18.0")
+  // XSDToSchema lives in different packages/APIs between spark-xml (Spark 3) and native XML (Spark 4).
+  def sources = T.sources {
+    super.sources() :+ PathRef(millSourcePath / "src" / "main" / (if (isNativeXml) "scala-spark4" else "scala-spark3"))
+  }
 }
 object xml extends Cross[XmlModule](crossMatrix)
 
@@ -141,7 +152,9 @@ object solr extends Cross[SolrModule](crossMatrix)
 
 trait DiffModule extends DfioModule {
   def moduleDeps = Seq(core())
-  def ivyDeps = Agg(ivy"uk.co.gresearch.spark::spark-extension:2.13.0-${sparkBinaryVersion}")
+  // spark-extension publishes per Spark binary version; 4.0 only exists from 2.15.0 onwards.
+  val diffVersion = if (sparkMajor.toInt >= 4) "2.15.0" else "2.13.0"
+  def ivyDeps = Agg(ivy"uk.co.gresearch.spark::spark-extension:$diffVersion-${sparkBinaryVersion}")
 }
 object diff extends Cross[DiffModule](crossMatrix)
 

--- a/core/src/main/scala/dev/mauch/spark/dfio/TransformerParser.scala
+++ b/core/src/main/scala/dev/mauch/spark/dfio/TransformerParser.scala
@@ -27,7 +27,7 @@ class SqlTransformerParser extends TransformerParser {
       case "sql-file" => scala.io.Source.fromFile(uri.getPath.substring(1)).mkString
     }
     df.createOrReplaceTempView("input")
-    df.sqlContext.sql(sql)
+    df.sparkSession.sql(sql)
   }
 }
 

--- a/xml/src/main/scala-spark3/dev/mauch/spark/dfio/XsdSchema.scala
+++ b/xml/src/main/scala-spark3/dev/mauch/spark/dfio/XsdSchema.scala
@@ -1,0 +1,11 @@
+package dev.mauch.spark.dfio
+
+import org.apache.spark.sql.types.StructType
+import com.databricks.spark.xml.util.XSDToSchema
+
+import java.nio.file.Paths
+
+// Spark 3.x: XSD -> schema via the databricks spark-xml library.
+object XsdSchema {
+  def read(path: String): StructType = XSDToSchema.read(Paths.get(path))
+}

--- a/xml/src/main/scala-spark4/dev/mauch/spark/dfio/XsdSchema.scala
+++ b/xml/src/main/scala-spark4/dev/mauch/spark/dfio/XsdSchema.scala
@@ -1,0 +1,11 @@
+package dev.mauch.spark.dfio
+
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.datasources.xml.XSDToSchema
+import org.apache.hadoop.fs.Path
+
+// Spark 4.x: XSD -> schema via the native XML datasource in spark-sql.
+// read(String) parses the string as XSD *content*, so use the Path overload to read from a file.
+object XsdSchema {
+  def read(path: String): StructType = XSDToSchema.read(new Path(path))
+}

--- a/xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala
+++ b/xml/src/main/scala/dev/mauch/spark/dfio/XmlFileDataFrameSource.scala
@@ -2,9 +2,6 @@ package dev.mauch.spark.dfio
 
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.apache.spark.sql.types.{StructField, StructType}
-import com.databricks.spark.xml.util.XSDToSchema
-
-import java.nio.file.Paths
 
 import UriHelpers._
 
@@ -13,9 +10,12 @@ case class XmlFileDataFrameSource(spark: SparkSession, path: String, options: Ma
     with DataFrameSink {
 
   private val xsdPath: Option[String] = options.get("xsd")
-  // xsd drives per-row validation on read; every other query param passes straight to spark-xml
+  // Default the element names to spark-xml's historical defaults. Spark 4's native XML *requires*
+  // rowTag, so this keeps the scheme usable without one and consistent across Spark versions.
+  private val taggedOptions: Map[String, String] = Map("rowTag" -> "ROW", "rootTag" -> "ROWS") ++ (options - "xsd")
+  // xsd drives per-row validation on read; every other query param passes straight to the XML datasource
   private val readOptions: Map[String, String] =
-    (options - "xsd") ++ xsdPath.map("rowValidationXSDPath" -> _)
+    taggedOptions ++ xsdPath.map("rowValidationXSDPath" -> _)
 
   override def read(): DataFrame = {
     val reader = spark.read.format("xml").options(readOptions)
@@ -24,19 +24,18 @@ case class XmlFileDataFrameSource(spark: SparkSession, path: String, options: Ma
   }
 
   // XSDToSchema returns the row element wrapped as a single struct field (e.g. the rowTag element);
-  // spark-xml expects the schema of one row's *contents*, so unwrap that single struct.
+  // the XML datasource expects the schema of one row's *contents*, so unwrap that single struct.
   private def rowSchemaFromXsd(xsd: String): StructType =
-    XSDToSchema.read(Paths.get(xsd)) match {
+    XsdSchema.read(xsd) match {
       case StructType(Array(StructField(_, inner: StructType, _, _))) => inner
       case other => other
     }
 
   override def write(df: DataFrame): Boolean = {
-    // spark-xml validates against an XSD on read only, so drop the xsd option when writing
     df.write
       .mode(SaveMode.Overwrite)
       .format("xml")
-      .options(options - "xsd")
+      .options(taggedOptions)
       .save(path)
     true
   }


### PR DESCRIPTION
Stacked on #113 (base branch: `add-xml-support`). Merge that first.

## What

Adds **Spark 4.0.0** to the cross-build matrix and switches the `xml` connector to Spark's **built-in XML datasource** on Spark 4 — which fixes the write-option limitation from #113 (spark-xml on Spark 3.x ignored `rowTag`/`rootTag` on write).

## How

- **`build.mill`**: `4.0.0` added to the **Scala 2.13-only** matrix (Spark 4 dropped 2.12, needs Java 17+). Per-Spark-version dependency selection where 3.x pins don't have 4.0 builds: `delta-spark` → `4.0.0`, `spark-extension` (diff) → `2.15.0-4.0`, `spark-excel` → `4.0.0_0.31.2`.
- **`xml` module**: drops the `spark-xml` dependency on Spark 4 (native), and uses **version-specific source dirs** (`scala-spark3` / `scala-spark4`) for the one API that differs — `XSDToSchema`, which moved to `org.apache.spark.sql.execution.datasources.xml` in Spark 4 (and whose `read(String)` parses content, not a path — the shim uses the `Path` overload). The connector now defaults `rowTag`/`rootTag` to `ROW`/`ROWS`, because Spark 4's native XML *requires* `rowTag`; this keeps the scheme usable without one and behaviour consistent across versions.
- **`core`**: `df.sqlContext` → `df.sparkSession` (`sqlContext` was removed from `DataFrame` in Spark 4; `sparkSession` works on both).
- **CI** (`ci.yml`): the matrix is generated from `mill resolve`, so `4.0.0` is picked up automatically; the job now selects **Java 17 for Spark 4.x** combos, Java 11 otherwise.

## Verification (local)

- All modules compile on `2.13.18/4.0.0` (Java 17): core, serde (abris), delta, avro, diff, kafka, solr, excel, uri-parser, etl, xml.
- `XmlEtlTest` passes on **both** Spark 3.5.8 (Java 11, spark-xml) and 4.0.0 (Java 17, native).
- **Payoff confirmed**: writing with `rowTag=person` → `<person>` elements on Spark 4.0.0 (`CONTAINS_PERSON=true`), vs `<ROW>` on Spark 3.5.8 (`CONTAINS_PERSON=false`). Native Spark 4 honors write options.

## Not verified locally

The heavier `etl` integration tests (Kafka→Delta, streaming) were **compile-verified** on Spark 4.0 but not run (need Docker + are slow) — CI will exercise them. If Delta/Kafka need Spark-4 runtime fixes, that's follow-up. `abris` (serde) is a Spark-3.2-provided library that compiles cleanly against the Spark 4 classpath, but its runtime behaviour on Spark 4 is likewise unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bg352v7gbKxXNY8LhWGcXA
